### PR TITLE
Make Spatie save only 1 picture per user.

### DIFF
--- a/app/Models/Student.php
+++ b/app/Models/Student.php
@@ -39,7 +39,8 @@ class Student extends Model implements HasMedia
     {
         $this->addMediaConversion('thumb')
             ->fit(Manipulations::FIT_MAX, 1200, 1200)
-            ->optimize();
+            ->optimize()
+            ->singleFile();
     }
 
     /** relations */


### PR DESCRIPTION
Hello,

This is the change I proposed a couple of days ago. 

Per Spatie's documentation here - 

https://spatie.be/docs/laravel-medialibrary/v8/working-with-media-collections/defining-media-collections#single-file-collections

This should delete old profile pictures when students upload new ones.

I synched my branch to be equal with the main academico project and saw that the factory changes were already implemented so no need for that.

* I'm having problems with making Spatie work on my forked copy so I didn't test this. If I get it working I'll test this and post the results here but I don't think it will be a problem. 

Best Regards.