### PR TITLE
More on course testing

### DIFF
--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -301,7 +301,7 @@ class Course extends Model
             foreach ($courseTimes as $courseTime) {
                 $initial = $daysInitials[$courseTime->day];
 
-                if (!isset($parsedCourseTimes[$initial])) {
+                if (! isset($parsedCourseTimes[$initial])) {
                     $parsedCourseTimes[$initial] = [];
                 }
 
@@ -315,7 +315,7 @@ class Course extends Model
 
         $result = '';
         foreach ($parsedCourseTimes as $day => $times) {
-            $result .= $day . ' -> ' . implode(' / ', $times) . ' | ';
+            $result .= $day.' -> '.implode(' / ', $times).' | ';
         }
 
         return trim($result, ' | ');

--- a/tests/Feature/CommentsTest.php
+++ b/tests/Feature/CommentsTest.php
@@ -13,7 +13,7 @@ class CommentsTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->seed('DatabaseSeeder');
+        //$this->seed('DatabaseSeeder');
     }
 
     /**

--- a/tests/Feature/CoreTest.php
+++ b/tests/Feature/CoreTest.php
@@ -15,7 +15,7 @@ class CoreTest extends TestCase
     {
         parent::setUp();
 
-        $this->seed('DatabaseSeeder');
+        $this->seed('TestSeeder');
     }
 
     /** @test */

--- a/tests/Feature/CoursesTest.php
+++ b/tests/Feature/CoursesTest.php
@@ -4,13 +4,10 @@ namespace Tests\Feature;
 
 use App\Models\Course;
 use App\Models\Period;
-use App\Models\Room;
-use App\Models\Teacher;
 use App\Models\User;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Response;
-use Illuminate\Support\Facades\View;
 use Tests\TestCase;
 
 class CoursesTest extends TestCase
@@ -93,15 +90,5 @@ class CoursesTest extends TestCase
         ]));
 
         $response->assertForbidden();
-    }
-
-    private function setSharedVariables()
-    {
-        View::share('periods', Period::orderBy('id', 'desc')->get());
-        View::share('current_period', Period::get_default_period());
-
-        View::share('teachers', Teacher::all());
-
-        View::share('rooms', Room::all());
     }
 }

--- a/tests/Feature/UpdateDataTest.php
+++ b/tests/Feature/UpdateDataTest.php
@@ -17,7 +17,7 @@ class UpdateDataTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->seed('DatabaseSeeder');
+        //$this->seed('DatabaseSeeder');
         $this->student = factory(Student::class)->create();
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,10 +2,25 @@
 
 namespace Tests;
 
+use App\Models\Period;
+use App\Models\Room;
+use App\Models\Teacher;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Illuminate\Support\Facades\View;
 use JMac\Testing\Traits\AdditionalAssertions;
 
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication, AdditionalAssertions;
+
+
+    protected function setSharedVariables()
+    {
+        View::share('periods', Period::orderBy('id', 'desc')->get());
+        View::share('current_period', Period::get_default_period());
+
+        View::share('teachers', Teacher::all());
+
+        View::share('rooms', Room::all());
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,7 +13,6 @@ abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication, AdditionalAssertions;
 
-
     protected function setSharedVariables()
     {
         View::share('periods', Period::orderBy('id', 'desc')->get());


### PR DESCRIPTION
@thdebay  Hey Thomas! 
I did a review on course features and tests implemented, and I just added a few more tests over the `course_times` attribute. With more than one CourseTime, the output was not looking good. Example:
```MS - 5:00 - 6:0011:12 - 12:03```
I did some changes, that are explained on the unit tests that I added. We can use another format if you prefer.

When I first review the course module, I thought in adding tests for "Course Skills", but that is for another module. I am thinking in working on this issue now https://github.com/academico-sis/academico/issues/180 and complete the test coverage for the feature, if that seems good to you. The course tests issue could be closed for now I guess.

Another detail is that I changed the names of the tests for the underscore style. It is the same but I prefer consistency :)

Finally, I moved the `setSharedVariables` method to the Test base class and commented/replaced some calls to `DatabaseSeeder`. Those tests were mostly empty, but the call to this heavy seeder delayed a lot the full test execution.

I wait for your comments. Thanks!

P.S.: I also removed the method `get_available_courses` on Course.php, because it was not in use.