### PR TITLE
Update ResultController.php to fix missing semicolon

### DIFF
--- a/app/Http/Controllers/ResultController.php
+++ b/app/Http/Controllers/ResultController.php
@@ -28,7 +28,7 @@ class ResultController extends Controller
         $result->result_type_id = $request->input('result');
 
         $result->save();
-        Enrollment::first()->student
+        Enrollment::first()->student;
         Log::info('Enrollment result saved by user '.backpack_user()->id);
 
         return $result;


### PR DESCRIPTION
There is a missing semicolon in ResultController.php introduced in a recent commit.  This PR corrects it.