### PR TITLE
Fixes on tests

### DIFF
--- a/database/seeders/TestSeeder.php
+++ b/database/seeders/TestSeeder.php
@@ -327,6 +327,10 @@ class TestSeeder extends Seeder
         factory(Level::class)->create(['name' => 'Intermediate']);
         factory(Level::class)->create(['name' => 'Advanced']);
 
-        factory(Period::class)->create();
+        $periodStartDate = now()->subDays(rand(1,30));
+        factory(Period::class)->create([
+            'start' => $periodStartDate,
+            'end' => $periodStartDate->addDays(90)
+        ]);
     }
 }

--- a/database/seeders/TestSeeder.php
+++ b/database/seeders/TestSeeder.php
@@ -327,10 +327,10 @@ class TestSeeder extends Seeder
         factory(Level::class)->create(['name' => 'Intermediate']);
         factory(Level::class)->create(['name' => 'Advanced']);
 
-        $periodStartDate = now()->subDays(rand(1,30));
+        $periodStartDate = now()->subDays(rand(1, 30));
         factory(Period::class)->create([
             'start' => $periodStartDate,
-            'end' => $periodStartDate->addDays(90)
+            'end' => $periodStartDate->addDays(90),
         ]);
     }
 }

--- a/tests/Unit/ChildCoursesTest.php
+++ b/tests/Unit/ChildCoursesTest.php
@@ -13,6 +13,14 @@ class ChildCoursesTest extends TestCase
 {
     use RefreshDatabase;
 
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setSharedVariables();
+        $this->seed('TestSeeder');
+    }
+
     public function test_that_an_enrollment_in_a_course_with_children_also_create_child_enrollments()
     {
         $parentCourse = factory(Course::class)->create();

--- a/tests/Unit/CoreTest.php
+++ b/tests/Unit/CoreTest.php
@@ -13,13 +13,13 @@ class CoreTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        //$this->seed('DatabaseSeeder');
+        $this->seed('TestSeeder');
     }
 
     /** @test */
     public function there_exists_a_current_period()
     {
-        $period = factory(Period::class)->create();
+        factory(Period::class)->create();
         $this->assertTrue(Period::get_default_period()->exists());
     }
 }

--- a/tests/Unit/CourseTest.php
+++ b/tests/Unit/CourseTest.php
@@ -15,6 +15,8 @@ class CourseTest extends TestCase
     {
         parent::setUp();
 
+        $this->seed('TestSeeder');
+
         $this->weeksUntilCourseStart = 5;
         $this->weeksUntilCourseEnd = 15;
         $this->initialStartDate = now()->addWeeks($this->weeksUntilCourseStart);

--- a/tests/Unit/PeriodReportsDataTest.php
+++ b/tests/Unit/PeriodReportsDataTest.php
@@ -13,6 +13,14 @@ class PeriodReportsDataTest extends TestCase
 {
     use RefreshDatabase;
 
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setSharedVariables();
+        $this->seed('TestSeeder');
+    }
+
     /**
      * Period->real_enrollments must return the count of pending enrollments in the period.
      */

--- a/tests/Unit/PeriodSelectionTest.php
+++ b/tests/Unit/PeriodSelectionTest.php
@@ -60,7 +60,6 @@ class PeriodSelectionTest extends TestCase
         ]);
 
         DB::table('config')->where('name', 'current_period')->update(['value' => null]);
-        Period::first()->delete();
 
         $this->assertEquals($period1->id, Period::get_default_period()->id);
     }


### PR DESCRIPTION
Hey Thomas! I checked your repo today and I realized that there were some problems with testing.

I saw that started when you merged my last contribution, that's weird since I always check for errors, but I should have checked the state of the code after the merge.

I reviewed the errors and are related to not-having a default period. I don't understand why these errors appear now and not before. Anyway, on the TestSeeder I verified that the current date is between start and end dates of the default period created.

Some of the tests required the default seeds, then I just added (I think this is moving to be some base setup for every test suite)

One of the tests for PeriodSelectionTests required a fix. I checked the logic and it seems that doing the delete is not required for the purpose of the test.

Let me know what you think about these changes.

Thanks!