### PR TITLE
quick fix for exception thrown on first time setup

### DIFF
--- a/database/migrations/2019_06_23_020202_create_config_table.php
+++ b/database/migrations/2019_06_23_020202_create_config_table.php
@@ -19,9 +19,9 @@ class CreateConfigTable extends Migration
             $table->string('value')->nullable();
             $table->timestamps();
         });
-
+        //default enrollment period set as first period
         DB::table('config')->insert([
-            ['name' => 'default_enrollment_period', 'value' => null],
+            ['name' => 'default_enrollment_period', 'value' => 1],
             ['name' => 'current_period', 'value' => null],
             ['name' => 'institution_rules_url', 'value' => null],
             ['name' => 'moodle_url', 'value' => null],


### PR DESCRIPTION
When you create a fresh installation and you log in the first time you will get an exception

**Trying to get property 'name' of non-object **

That's because, in Home Controller variable $enrollmentsPeriod returns null, it doesn't check if the enrollment is the first time, so to get it working you need to specify in config table directly id of enrollment so you can get it going.

I can see that you have the field named "first_period" I think that is for the fresh applications so changing Config migration and hardcoding the id on default_enrollment_period isn't the option.

A quick fix is attached, but If I had more time I would create a better approach on this one!