### PR TITLE
Fix: When a new course is created, the start and end date should automatically display the selected period's dates.

### DIFF
--- a/app/Http/Controllers/Admin/CourseCrudController.php
+++ b/app/Http/Controllers/Admin/CourseCrudController.php
@@ -418,6 +418,8 @@ class CourseCrudController extends CrudController
 
     protected function addCourseScheduleFields()
     {
+        $defaultPeriod = Period::get_default_period();
+
         CRUD::addFields([
             [
                 'label' => __('Period'),
@@ -426,6 +428,7 @@ class CourseCrudController extends CrudController
                 'entity' => 'period',
                 'attribute' => 'name',
                 'model' => Period::class,
+                'default' => $defaultPeriod->id,
                 'tab' => __('Schedule'),
             ],
 
@@ -433,6 +436,7 @@ class CourseCrudController extends CrudController
                 'name' => 'start_date',
                 'label' => __('Start Date'),
                 'type' => 'date',
+                'default' => $defaultPeriod->start,
                 'tab' => __('Schedule'),
             ],
 
@@ -440,6 +444,7 @@ class CourseCrudController extends CrudController
                 'name' => 'end_date',
                 'label' => __('End Date'),
                 'type' => 'date',
+                'default' => $defaultPeriod->end,
                 'tab' => __('Schedule'),
             ],
         ]);

--- a/app/Models/Period.php
+++ b/app/Models/Period.php
@@ -39,6 +39,8 @@ class Period extends Model
     /**
      * Return the current period to be used as a default system-wide.
      * First look in Config DB table; otherwise select current or closest next period.
+     *
+     * @return self
      */
     public static function get_default_period()
     {


### PR DESCRIPTION
https://github.com/academico-sis/academico/issues/282

I'm not confident that this is the best solution. But, it's the simplest and should cover most of the cases. 
